### PR TITLE
Align vocab indices for keras preprocessing lookup layers when invert…

### DIFF
--- a/keras/integration_test/tpu_strategy_test.py
+++ b/keras/integration_test/tpu_strategy_test.py
@@ -91,7 +91,7 @@ class TpuStrategyTest(tf.test.TestCase):
     # Only needed for serving.
     label_inverse_lookup_layer = (
         tf.keras.layers.experimental.preprocessing.StringLookup(
-            num_oov_indices=1,
+            num_oov_indices=0,
             mask_token=None,
             vocabulary=LABEL_VOCAB,
             invert=True))


### PR DESCRIPTION
…=True

This change ensures that lookup layers with equal configs and vocabs will use the same indexing when doing forward and inverse lookups. It also adds support for any value of num_oov_indices when invert=True.

Fixes a couple bugs related to getting and setting vocabs:
 - set_vocabulary can now be called if num_oov_indices > 1
 - get_vocabulary will return correct results when num_oov_indices > 1

PiperOrigin-RevId: 358956952